### PR TITLE
Update color parameter in HA component

### DIFF
--- a/custom_components/light/yeelight_bt.py
+++ b/custom_components/light/yeelight_bt.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_MAC
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT,
     ATTR_RGB_COLOR, SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_RGB_COLOR, SUPPORT_WHITE_VALUE,
+    SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_COLOR, SUPPORT_WHITE_VALUE,
     Light, PLATFORM_SCHEMA)
 
 from homeassistant.util.color import (
@@ -40,7 +40,7 @@ LIGHT_EFFECT_LIST = ['flow', 'none']
 
 SUPPORT_YEELIGHTBT = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
                       # SUPPORT_EFFECT |
-                      SUPPORT_RGB_COLOR | SUPPORT_WHITE_VALUE)
+                      SUPPORT_COLOR | SUPPORT_WHITE_VALUE)
 
 _LOGGER = logging.getLogger(__name__)
 

--- a/custom_components/yeelight_bt/light/yeelight_bt.py
+++ b/custom_components/yeelight_bt/light/yeelight_bt.py
@@ -16,7 +16,7 @@ from homeassistant.const import CONF_DEVICES, CONF_NAME, CONF_MAC
 from homeassistant.components.light import (
     ATTR_BRIGHTNESS, ATTR_COLOR_TEMP, ATTR_EFFECT,
     ATTR_RGB_COLOR, SUPPORT_BRIGHTNESS,
-    SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_RGB_COLOR, SUPPORT_WHITE_VALUE,
+    SUPPORT_COLOR_TEMP, SUPPORT_EFFECT, SUPPORT_COLOR, SUPPORT_WHITE_VALUE,
     Light, PLATFORM_SCHEMA)
 
 from homeassistant.util.color import (
@@ -40,7 +40,7 @@ LIGHT_EFFECT_LIST = ['flow', 'none']
 
 SUPPORT_YEELIGHTBT = (SUPPORT_BRIGHTNESS | SUPPORT_COLOR_TEMP |
                       # SUPPORT_EFFECT |
-                      SUPPORT_RGB_COLOR | SUPPORT_WHITE_VALUE)
+                      SUPPORT_COLOR | SUPPORT_WHITE_VALUE)
 
 _LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
Since [9b1a75a](https://github.com/home-assistant/home-assistant/commit/89c7c80e42c769857389a3edda2a874b63f974f5#diff-685ba8a5bcd2c24b5af57da8529e8ce9) in [Home Assistant repo](https://github.com/home-assistant/home-assistantl), SUPPORT_RGB_COLOR became SUPPORT_COLOR.